### PR TITLE
revise 12_StringPathInMatrix

### DIFF
--- a/12_StringPathInMatrix/StringPathInMatrix.cpp
+++ b/12_StringPathInMatrix/StringPathInMatrix.cpp
@@ -47,6 +47,7 @@ bool hasPath(const char* matrix, int rows, int cols, const char* str)
             if(hasPathCore(matrix, rows, cols, row, col, str,
                 pathLength, visited))
             {
+                delete[] visited;
                 return true;
             }
         }


### PR DESCRIPTION
"12_StringPathInMatrix.cpp" do not release pointer "visited" if path is found.

"12_StringPathInMatrix.cpp" 中，当path被找到时，函数直接return，指针"visited"没有正确被释放