### PR TITLE
修复删除元素的错误

### DIFF
--- a/09_QueueWithTwoStacks/Queue.h
+++ b/09_QueueWithTwoStacks/Queue.h
@@ -59,6 +59,7 @@ template<typename T> T CQueue<T>::deleteHead()
         while(!stack1.empty())
         {
             stack2.push(stack1.top());
+            stack1.pop();
         }
     }
 

--- a/09_QueueWithTwoStacks/Queue.h
+++ b/09_QueueWithTwoStacks/Queue.h
@@ -54,13 +54,11 @@ template<typename T> void CQueue<T>::appendTail(const T& element)
 
 template<typename T> T CQueue<T>::deleteHead()
 {
-    if(stack2.size()<= 0)
+    if(stack2.empty())
     {
-        while(stack1.size()>0)
+        while(!stack1.empty())
         {
-            T& data = stack1.top();
-            stack1.pop();
-            stack2.push(data);
+            stack2.push(stack1.top());
         }
     }
 


### PR DESCRIPTION
原代码中在stack1将顶部元素pop后，data仍保留有其引用，而程序此时有可能已将其内存释放，data引用的是无效的元素，更正为直接将stack1顶部元素push进stack2。