### PR TITLE
Utilities下，BinaryTree.h和BinaryTree.cpp中的DestroyTree()参数要加引用

### DIFF
--- a/Utilities/BinaryTree.cpp
+++ b/Utilities/BinaryTree.cpp
@@ -8,8 +8,8 @@ https://github.com/zhedahht/CodingInterviewChinese2/blob/master/LICENSE.txt)
 *******************************************************************/
 
 //==================================================================
-// ¡¶½£Ö¸Offer¡ª¡ªÃûÆóÃæÊÔ¹Ù¾«½²µäĞÍ±à³ÌÌâ¡·´úÂë
-// ×÷Õß£ººÎº£ÌÎ
+// ã€Šå‰‘æŒ‡Offerâ€”â€”åä¼é¢è¯•å®˜ç²¾è®²å…¸å‹ç¼–ç¨‹é¢˜ã€‹ä»£ç 
+// ä½œè€…ï¼šä½•æµ·æ¶›
 //==================================================================
 
 #include <cstdio>
@@ -72,7 +72,7 @@ void PrintTree(const BinaryTreeNode* pRoot)
     }
 }
 
-void DestroyTree(BinaryTreeNode* pRoot)
+void DestroyTree(BinaryTreeNode*& pRoot)
 {
     if(pRoot != nullptr)
     {

--- a/Utilities/BinaryTree.h
+++ b/Utilities/BinaryTree.h
@@ -8,8 +8,8 @@ https://github.com/zhedahht/CodingInterviewChinese2/blob/master/LICENSE.txt)
 *******************************************************************/
 
 //==================================================================
-// ¡¶½£Ö¸Offer¡ª¡ªÃûÆóÃæÊÔ¹Ù¾«½²µäĞÍ±à³ÌÌâ¡·´úÂë
-// ×÷Õß£ººÎº£ÌÎ
+// ã€Šå‰‘æŒ‡Offerâ€”â€”åä¼é¢è¯•å®˜ç²¾è®²å…¸å‹ç¼–ç¨‹é¢˜ã€‹ä»£ç 
+// ä½œè€…ï¼šä½•æµ·æ¶›
 //==================================================================
 
 #pragma once
@@ -25,4 +25,4 @@ __declspec( dllexport ) BinaryTreeNode* CreateBinaryTreeNode(int value);
 __declspec( dllexport ) void ConnectTreeNodes(BinaryTreeNode* pParent, BinaryTreeNode* pLeft, BinaryTreeNode* pRight);
 __declspec( dllexport ) void PrintTreeNode(const BinaryTreeNode* pNode);
 __declspec( dllexport ) void PrintTree(const BinaryTreeNode* pRoot);
-__declspec( dllexport ) void DestroyTree(BinaryTreeNode* pRoot);
+__declspec( dllexport ) void DestroyTree(BinaryTreeNode*& pRoot);


### PR DESCRIPTION
Utilities下，BinaryTree.h和BinaryTree.cpp中的void DestroyTree(BinaryTreeNode* pRoot)参数要加引用，即改为void DestroyTree(BinaryTreeNode*& pRoot)。
因为对指针有释放内存，并赋值为nullptr。只有加上引用，赋值才能生效。否则会成为野指针。