### PR TITLE
Fix typo in NumberAppearingOnce.cpp

### DIFF
--- a/56_02_NumberAppearingOnce/NumberAppearingOnce.cpp
+++ b/56_02_NumberAppearingOnce/NumberAppearingOnce.cpp
@@ -8,13 +8,13 @@ https://github.com/zhedahht/CodingInterviewChinese2/blob/master/LICENSE.txt)
 *******************************************************************/
 
 //==================================================================
-// ¡¶½£Ö¸Offer¡ª¡ªÃûÆóÃæÊÔ¹Ù¾«½²µäĞÍ±à³ÌÌâ¡·´úÂë
-// ×÷Õß£ººÎº£ÌÎ
+// ã€Šå‰‘æŒ‡Offerâ€”â€”åä¼é¢è¯•å®˜ç²¾è®²å…¸å‹ç¼–ç¨‹é¢˜ã€‹ä»£ç 
+// ä½œè€…ï¼šä½•æµ·æ¶›
 //==================================================================
 
-// ÃæÊÔÌâ56£¨¶ş£©£ºÊı×éÖĞÎ¨Ò»Ö»³öÏÖÒ»´ÎµÄÊı×Ö
-// ÌâÄ¿£ºÔÚÒ»¸öÊı×éÖĞ³ıÁËÒ»¸öÊı×ÖÖ»³öÏÖÒ»´ÎÖ®Íâ£¬ÆäËûÊı×Ö¶¼³öÏÖÁËÈı´Î¡£Çë
-// ÕÒ³öÄÇ¸ö³Ô³öÏÖÒ»´ÎµÄÊı×Ö¡£
+// é¢è¯•é¢˜56ï¼ˆäºŒï¼‰ï¼šæ•°ç»„ä¸­å”¯ä¸€åªå‡ºç°ä¸€æ¬¡çš„æ•°å­—
+// é¢˜ç›®ï¼šåœ¨ä¸€ä¸ªæ•°ç»„ä¸­é™¤äº†ä¸€ä¸ªæ•°å­—åªå‡ºç°ä¸€æ¬¡ä¹‹å¤–ï¼Œå…¶ä»–æ•°å­—éƒ½å‡ºç°äº†ä¸‰æ¬¡ã€‚è¯·
+// æ‰¾å‡ºé‚£ä¸ªåªå‡ºç°ä¸€æ¬¡çš„æ•°å­—ã€‚
 
 #include <cstdio>
 #include <exception>
@@ -48,7 +48,7 @@ int FindNumberAppearingOnce(int numbers[], int length)
     return result;
 }
 
-// ====================²âÊÔ´úÂë====================
+// ====================æµ‹è¯•ä»£ç ====================
 void Test(const char* testName, int numbers[], int length, int expected)
 {
     int result = FindNumberAppearingOnce(numbers, length);
@@ -58,7 +58,7 @@ void Test(const char* testName, int numbers[], int length, int expected)
         printf("%s FAILED.\n", testName);
 }
 
-// ËùÓĞÊı×Ö¶¼ÊÇÕıÊı£¬Î¨Ò»µÄÊı×ÖÊÇ×îĞ¡µÄ
+// æ‰€æœ‰æ•°å­—éƒ½æ˜¯æ­£æ•°ï¼Œå”¯ä¸€çš„æ•°å­—æ˜¯æœ€å°çš„
 void Test1()
 {
     int numbers[] = { 1, 1, 2, 2, 2, 1, 3 };
@@ -66,7 +66,7 @@ void Test1()
     Test("Test1", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// ËùÓĞÊı×Ö¶¼ÊÇÕıÊı£¬Î¨Ò»µÄÊı×ÖµÄ´óĞ¡Î»ÓÚÖĞ¼ä
+// æ‰€æœ‰æ•°å­—éƒ½æ˜¯æ­£æ•°ï¼Œå”¯ä¸€çš„æ•°å­—çš„å¤§å°ä½äºä¸­é—´
 void Test2()
 {
     int numbers[] = { 4, 3, 3, 2, 2, 2, 3 };
@@ -74,7 +74,7 @@ void Test2()
     Test("Test2", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// ËùÓĞÊı×Ö¶¼ÊÇÕıÊı£¬Î¨Ò»µÄÊı×ÖÊÇ×î´óµÄ
+// æ‰€æœ‰æ•°å­—éƒ½æ˜¯æ­£æ•°ï¼Œå”¯ä¸€çš„æ•°å­—æ˜¯æœ€å¤§çš„
 void Test3()
 {
     int numbers[] = { 4, 4, 1, 1, 1, 7, 4 };
@@ -82,7 +82,7 @@ void Test3()
     Test("Test3", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// Î¨Ò»µÄÊı×ÖÊÇ¸ºÊı
+// å”¯ä¸€çš„æ•°å­—æ˜¯è´Ÿæ•°
 void Test4()
 {
     int numbers[] = { -10, 214, 214, 214 };
@@ -90,7 +90,7 @@ void Test4()
     Test("Test4", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// ³ıÁËÎ¨Ò»µÄÊı×Ö£¬ÆäËûÊı×Ö¶¼ÊÇ¸ºÊı
+// é™¤äº†å”¯ä¸€çš„æ•°å­—ï¼Œå…¶ä»–æ•°å­—éƒ½æ˜¯è´Ÿæ•°
 void Test5()
 {
     int numbers[] = { -209, 3467, -209, -209 };
@@ -98,7 +98,7 @@ void Test5()
     Test("Test5", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// ÖØ¸´µÄÊı×ÖÓĞÕıÊıÒ²ÓĞ¸ºÊı
+// é‡å¤çš„æ•°å­—æœ‰æ­£æ•°ä¹Ÿæœ‰è´Ÿæ•°
 void Test6()
 {
     int numbers[] = { 1024, -1025, 1024, -1025, 1024, -1025, 1023 };
@@ -106,7 +106,7 @@ void Test6()
     Test("Test6", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// ËùÓĞÊı×Ö¶¼ÊÇ¸ºÊı
+// æ‰€æœ‰æ•°å­—éƒ½æ˜¯è´Ÿæ•°
 void Test7()
 {
     int numbers[] = { -1024, -1024, -1024, -1023 };
@@ -114,7 +114,7 @@ void Test7()
     Test("Test7", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// Î¨Ò»µÄÊı×ÖÊÇ0
+// å”¯ä¸€çš„æ•°å­—æ˜¯0
 void Test8()
 {
     int numbers[] = { -23, 0, 214, -23, 214, -23, 214 };
@@ -122,7 +122,7 @@ void Test8()
     Test("Test8", numbers, sizeof(numbers) / sizeof(int), expected);
 }
 
-// ³ıÁËÎ¨Ò»µÄÊı×Ö£¬ÆäËûÊı×Ö¶¼ÊÇ0
+// é™¤äº†å”¯ä¸€çš„æ•°å­—ï¼Œå…¶ä»–æ•°å­—éƒ½æ˜¯0
 void Test9()
 {
     int numbers[] = { 0, 3467, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
注释题目里”吃“应为”只“，其它标红显示改动为GitHub的编码自动转换导致。